### PR TITLE
Clean up security headers in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,11 +28,7 @@
     
     <!-- Security Headers (via meta tags) -->
     <!-- Note: 'unsafe-inline' is used for inline styles and scripts. Consider using nonces or external files for stricter CSP in production. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://api.github.com https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://api.github.com https://plausible.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
-    <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-    <meta http-equiv="Permissions-Policy" content="geolocation=(), microphone=(), camera=(), payment=()">
-    
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://api.github.com https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' data:; connect-src 'self' https://api.github.com https://plausible.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"> 
     <!-- PWA Support -->
     <meta name="theme-color" content="#ffffff">
     <meta name="apple-mobile-web-app-capable" content="yes">


### PR DESCRIPTION
Removed redundant security headers from index.html.

## 概要
(もしあれば)
- 関連するIssue: #

## 変更の種類
- [ ] ✨ 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug Fix)
- [ ] ⚡ パフォーマンス改善 (Performance)
- [ ] 📖 ドキュメント整備 (Documentation)
- [ ] 🔧 その他 (Refactoring, CI/CD, etc...)

## 変更内容
- 
- 

## 使用例
```julia
# 実装した機能の使用例

```
## check list
- [ ] test駆動をしたか
- [ ] Project.tomlのバージョンを上げたか
