### PR TITLE
chore(seo): declare obsidian-remote-ssh sitemap in root robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
-# Last updated: 2026-05-01
+# Last updated: 2026-05-11
 # robots.txt for codes.sota-shimozono.com
 
 User-agent: *
@@ -6,6 +6,7 @@ Allow: /
 
 # Sitemaps
 Sitemap: https://codes.sota-shimozono.com/sitemap.xml
+Sitemap: https://codes.sota-shimozono.com/obsidian-remote-ssh/sitemap.xml
 
 # Common crawler directives
 User-agent: Googlebot


### PR DESCRIPTION
## Summary

Add the docs sitemap for [obsidian-remote-ssh](https://codes.sota-shimozono.com/obsidian-remote-ssh/) as a second `Sitemap:` directive in the root robots.txt.

### Why

The docs site lives at `https://codes.sota-shimozono.com/obsidian-remote-ssh/` and ships with its own `sitemap.xml` (95 URLs) generated by Quartz. That sitemap was registered directly with Google Search Console + Bing Webmaster Tools, but the root robots.txt — which crawlers use as a discovery hint — only pointed at the personal site's sitemap.

Multiple `Sitemap:` lines in a single robots.txt are valid per the protocol. Both Google and Bing follow all of them.

### Test plan

- [ ] After merge + deploy: `curl https://codes.sota-shimozono.com/robots.txt` shows both `Sitemap:` lines
- [ ] After ~24h: Google Search Console "Sitemaps" report shows the docs sitemap as "Discovered via robots.txt" (in addition to the manual submission)