### PR TITLE
feat(zola): add Zola scaffold for portfolio rebuild (PR-2a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 docs/build/
 Manifest.toml
+
+# Zola
+/public
+.zola-cache

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,39 @@
+base_url = "https://codes.sota-shimozono.com"
+title = "Sota Shimozono - Physics & Code Portfolio"
+description = "Open-source Julia libraries for lattice physics — LatticeCore.jl, Lattice2D.jl, QuasiCrystal.jl, QAtlas.jl, Reversi.jl."
+default_language = "ja"
+compile_sass = true
+generate_feeds = true
+feed_filenames = ["atom.xml"]
+build_search_index = false
+minify_html = true
+
+taxonomies = [
+    { name = "category", feed = true },
+    { name = "language" },
+]
+
+[languages.en]
+taxonomies = [
+    { name = "category", feed = true },
+    { name = "language" },
+]
+title = "Sota Shimozono - Physics & Code Portfolio"
+description = "Open-source Julia libraries for lattice physics."
+generate_feeds = true
+feed_filenames = ["atom.xml"]
+
+[markdown]
+external_links_target_blank = true
+external_links_no_referrer = true
+smart_punctuation = true
+
+[extra]
+author = "Sota Shimozono"
+author_ja = "下薗創太"
+github_user = "sotashimozono"
+official_site = "https://sota-shimozono.com"
+og_image = "/og/codes-1200x630.png"
+affiliation = "The University of Tokyo"
+affiliation_ja = "東京大学"
+twitter_creator = "@sotashimozono"

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,0 +1,14 @@
++++
+title = "Sota Shimozono - Physics & Code Portfolio"
+description = "Open-source Julia libraries for lattice physics."
+sort_by = "weight"
+template = "index.html"
++++
+
+A graduate student in theoretical physics at the University of Tokyo,
+working on quantum many-body systems and lattice models. I publish a
+small family of Julia libraries that backs my research.
+
+Package documentation lives behind the **docs** links on each card.
+For research notes and a blog, see
+[Official Site (Blog, Tea)](https://sota-shimozono.com).

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,12 @@
++++
+title = "Sota Shimozono - Physics & Code Portfolio"
+description = "Open-source Julia libraries for lattice physics — LatticeCore.jl, Lattice2D.jl, QuasiCrystal.jl, QAtlas.jl, Reversi.jl."
+sort_by = "weight"
+template = "index.html"
++++
+
+理論物理を専攻する大学院生 (東京大学) として、量子多体系と格子模型を扱う
+ための Julia パッケージ群をオープンソースで公開しています。
+
+各パッケージのドキュメントは下のカードの **docs** リンクから。研究記録と
+ブログは [Official Site (Blog, Tea)](https://sota-shimozono.com) に。

--- a/content/works/_index.en.md
+++ b/content/works/_index.en.md
@@ -1,0 +1,6 @@
++++
+title = "Works"
+description = "Open-source Julia libraries for lattice physics and related research."
+sort_by = "weight"
+template = "section.html"
++++

--- a/content/works/_index.md
+++ b/content/works/_index.md
@@ -1,0 +1,6 @@
++++
+title = "Works"
+description = "Open-source Julia libraries for lattice physics and related research."
+sort_by = "weight"
+template = "section.html"
++++

--- a/content/works/lattice-2d.md
+++ b/content/works/lattice-2d.md
@@ -1,0 +1,46 @@
++++
+title = "Lattice2D.jl"
+description = "Square / Triangular / Honeycomb / Kagome / Lieb / Shastry-Sutherland — unit-cell driven 2D lattices."
+date = 2026-05-11
+weight = 20
+
+[taxonomies]
+category = ["Lattice Suite"]
+language = ["Julia"]
+
+[extra]
+role = "Geometry"
+repo = "https://github.com/sotashimozono/Lattice2D.jl"
+docs_stable = "/Lattice2D.jl/stable/"
+docs_dev = "/Lattice2D.jl/dev/"
+julia_min = "1.10"
+tagline_en = "Two-dimensional lattices built from unit cells"
+tagline_ja = "ユニットセルから組み立てる2次元格子"
+depends_on = ["lattice-core"]
++++
+
+Provides two-dimensional lattices. Given unit-cell information (basis
+vectors and connections), arbitrary lattices can be constructed.
+Reciprocal vectors, bipartiteness checks, and periodic / open boundary
+conditions are first-class. Plotting is available through `materialize`
+and `require_finite` (re-exported).
+
+## Available lattices
+
+- Square lattice
+- Triangular lattice
+- Honeycomb lattice
+- Kagome lattice
+- Lieb lattice
+- Shastry-Sutherland lattice
+
+## Example
+
+```julia
+using Lattice2D
+
+# 4x4 Honeycomb lattice with periodic boundary conditions
+lat = build_lattice(Honeycomb, 4, 4; boundary=PBC())
+println("Total sites: ", lat.N)
+println("Is bipartite? ", lat.is_bipartite)
+```

--- a/content/works/lattice-core.md
+++ b/content/works/lattice-core.md
@@ -1,0 +1,37 @@
++++
+title = "LatticeCore.jl"
+description = "Abstract lattice interface — traits, BC composition, momentum space (FFT / NUFFT)."
+date = 2026-05-11
+weight = 10
+
+[taxonomies]
+category = ["Lattice Suite"]
+language = ["Julia"]
+
+[extra]
+role = "Foundation"
+repo = "https://github.com/sotashimozono/LatticeCore.jl"
+docs_stable = "/LatticeCore.jl/stable/"
+docs_dev = "/LatticeCore.jl/dev/"
+julia_min = "1.10"
+tagline_en = "Abstract lattice interface for quantum many-body simulations"
+tagline_ja = "量子多体シミュレーション向けの抽象格子インターフェース"
+depends_on = []
++++
+
+LatticeCore is the interface layer for a family of Julia packages that
+simulate physical systems on geometric lattices. It defines the types
+and trait vocabulary that every lattice — periodic or aperiodic, finite
+or conceptually infinite — must implement, then ships a pair of
+reference implementations (`LineLattice`, `SimpleSquareLattice`) and a
+momentum-space layer so the interface is verifiable end-to-end without
+any other dependency.
+
+## Highlights
+
+- `AbstractLattice{D, T}` with trait-based extension (`TopologyTrait`, `Periodic` / `Aperiodic`, `is_bipartite`, `reciprocal_support`, `size_trait`).
+- Per-axis boundary conditions (`PeriodicAxis`, `OpenAxis`, `TwistedAxis`) composed into a `LatticeBoundary`. Mixed BCs (cylinders) are first-class.
+- Coordinate system and indexing split: `RealSpace`, `LatticeCoord`, `HigherDimCoord`, plus `RowMajor` / `ColMajor` / `Snake` strategies decoupled from coordinates.
+- Site types (`IsingSite`, `PottsSite{Q}`, `XYSite`, `HeisenbergSite`, `EmptySite`) through three layouts (`UniformLayout`, `SublatticeLayout`, `ExplicitLayout`) so mixed-spin and disordered models compose cleanly.
+- Element centering trait (`VertexCenter` default, `BondCenter` / `PlaquetteCenter` / `CellCenter` as extension points) for dimer, gauge-link, and flux variables.
+- Momentum-space layer: `AbstractMomentumLattice`, `PeriodicMomentumLattice`, `monkhorst_pack` / `gamma_centered` meshes, and `structure_factor` with trait-dispatched fast paths (`LatticeCoreFFTWExt` for Bravais; `LatticeCoreNFFTExt` reserved for the quasicrystal case).

--- a/content/works/qatlas.md
+++ b/content/works/qatlas.md
@@ -1,0 +1,44 @@
++++
+title = "QAtlas.jl"
+description = "Publication-traced reference table for quantum many-body physics — confidence-tiered, cross-checked."
+date = 2026-05-11
+weight = 40
+
+[taxonomies]
+category = ["Reference Data"]
+language = ["Julia"]
+
+[extra]
+role = "Reference DB"
+repo = "https://github.com/sotashimozono/QAtlas.jl"
+docs_stable = "/QAtlas.jl/stable/"
+docs_dev = "/QAtlas.jl/dev/"
+julia_min = "1.12"
+tagline_en = "Curated dictionary of rigorous results in quantum and statistical physics"
+tagline_ja = "量子・統計物理の厳密結果を整理した参照テーブル"
+depends_on = []
++++
+
+QAtlas exposes a curated dictionary of rigorous results in quantum and
+statistical physics. Every stored value traces back to a specific
+publication and is cross-validated against independent numerical
+computations (dense / sparse exact diagonalisation, brute-force
+enumeration, Bloch diagonalisation, automatic differentiation,
+bipartite fluctuations, …).
+
+## Confidence tiers
+
+- **Highest confidence**: results the maintainer derives and checks line-by-line (TFIM BdG + thermodynamics, Onsager $T_c$, Yang $M(T)$, Heisenberg dimer, bipartite-fluctuation Luttinger $K$, PBC Calabrese–Cardy central charge).
+- **Cross-checked**: tight-binding Bloch formulas, 3D O(N) bootstrap values, $E_8$ mass ratios — verified numerically but not all re-derived by hand.
+
+> If you use QAtlas values in a publication, verify them against the
+> cited original references.
+
+## Status
+
+The source and the derivation notes are written with heavy LLM
+assistance and are being independently reviewed. Found an error — a
+formula, a proof step, a citation, a type signature? Please
+[open an issue](https://github.com/sotashimozono/QAtlas.jl/issues).
+Recent review cycles have already caught one flagship bug ($E_8$ mass
+ratios $m_7, m_8$ were 2× the literature value, fixed in PR #83).

--- a/content/works/quasi-crystal.md
+++ b/content/works/quasi-crystal.md
@@ -1,0 +1,37 @@
++++
+title = "QuasiCrystal.jl"
+description = "Aperiodic lattices: Fibonacci / Penrose / Ammann-Beenker — unified with `AbstractLattice`."
+date = 2026-05-11
+weight = 30
+
+[taxonomies]
+category = ["Lattice Suite"]
+language = ["Julia"]
+
+[extra]
+role = "Geometry"
+repo = "https://github.com/sotashimozono/QuasiCrystal.jl"
+docs_stable = "/QuasiCrystal.jl/stable/"
+docs_dev = "/QuasiCrystal.jl/dev/"
+julia_min = "1.10"
+tagline_en = "Aperiodic structures via the AbstractLattice interface"
+tagline_ja = "AbstractLattice インターフェース上の準結晶構造"
+depends_on = ["lattice-core"]
++++
+
+Quasicrystal structures (Fibonacci sequence, Penrose tile,
+Ammann-Beenker lattice) accessible through the same `AbstractLattice{D}`
+interface as periodic lattices, so downstream Monte Carlo / spectral
+codes can run uniformly on either kind of structure.
+
+## Available structures
+
+- Fibonacci Lattice
+- Penrose Tile
+- Ammann-Beenker Lattice
+
+## Unified interface
+
+Periodic lattices and quasicrystals expose the same methods:
+`get_positions`, `get_bonds`, `get_nearest_neighbors`, `num_sites`,
+`num_bonds`. Package quality is checked on CI via Aqua.jl (`Aqua.test_all`).

--- a/content/works/reversi.md
+++ b/content/works/reversi.md
@@ -1,0 +1,41 @@
++++
+title = "Reversi.jl"
+description = "High-performance Othello on StaticArrays — designed for ML/RL research."
+date = 2026-05-11
+weight = 50
+
+[taxonomies]
+category = ["Game / RL"]
+language = ["Julia"]
+
+[extra]
+role = "Game / RL"
+repo = "https://github.com/sotashimozono/Reversi.jl"
+docs_stable = "/Reversi.jl/stable/"
+docs_dev = "/Reversi.jl/dev/"
+julia_min = "1.12"
+tagline_en = "Reversi/Othello engine with a clean RL-friendly API"
+tagline_ja = "強化学習に組み込みやすい高速 Othello エンジン"
+depends_on = []
++++
+
+A high-performance Reversi (Othello) implementation in Julia, built on
+StaticArrays.jl for efficient board representation. Designed with
+flexibility for machine learning and reinforcement learning research.
+
+## Features
+
+- **Efficient implementation**: StaticArrays.jl for fast, stack-allocated boards.
+- **Terminal gameplay**: play interactively in the terminal.
+- **Flexible player system**: easy to plug in custom AI players and ML models.
+- **Clean API**: simple, well-documented interface for programmatic control.
+- **Extensible**: abstract player interface allows new strategies.
+
+## Quick start
+
+```julia
+using Reversi
+
+# Human vs Random AI
+play_game(HumanPlayer(), RandomPlayer())
+```

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -1,0 +1,194 @@
+:root {
+    --bg: #fafafa;
+    --fg: #18181b;
+    --muted: #6b7280;
+    --accent: #5b21b6;
+    --accent-soft: #ede9fe;
+    --card: #ffffff;
+    --border: #e5e7eb;
+    --code-bg: #f3f4f6;
+    --max-w: 960px;
+    --radius: 12px;
+    --shadow: 0 1px 2px rgba(0,0,0,.04), 0 4px 12px rgba(0,0,0,.04);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0b0b0c;
+        --fg: #f5f5f5;
+        --muted: #a1a1aa;
+        --accent: #c4b5fd;
+        --accent-soft: #2a1d52;
+        --card: #131316;
+        --border: #27272a;
+        --code-bg: #1c1c1f;
+        --shadow: 0 1px 2px rgba(0,0,0,.4), 0 6px 24px rgba(0,0,0,.3);
+    }
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic UI", Meiryo, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+}
+
+code, pre, .badge.minver {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono", Menlo, Consolas, monospace;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.skip-link {
+    position: absolute; top: -3em; left: 0;
+    background: var(--fg); color: var(--bg);
+    padding: .5em 1em;
+    z-index: 100;
+}
+.skip-link:focus { top: 0; }
+
+.container {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 0 1.25rem;
+}
+
+.site-header {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+    position: sticky; top: 0; z-index: 10;
+    backdrop-filter: saturate(180%) blur(8px);
+}
+.site-header .container {
+    display: flex; align-items: center; justify-content: space-between;
+    padding-top: .75rem; padding-bottom: .75rem;
+}
+.brand { font-weight: 700; color: var(--fg); }
+.site-nav { display: flex; gap: 1rem; align-items: center; }
+.site-nav a { color: var(--muted); font-size: .92em; }
+.site-nav a:hover { color: var(--fg); text-decoration: none; }
+.lang-toggle {
+    border: 1px solid var(--border);
+    padding: .15em .5em;
+    border-radius: 6px;
+    font-size: .82em;
+}
+
+main { padding: 2.5rem 0 4rem; }
+
+.hero h1 {
+    font-size: clamp(1.6rem, 2.2vw + 1rem, 2.4rem);
+    line-height: 1.2;
+    letter-spacing: -.01em;
+    margin: 0 0 .8rem;
+}
+.accent { color: var(--accent); }
+.lead { color: var(--muted); font-size: 1.05rem; max-width: 38rem; }
+
+.works {
+    margin-top: 3rem;
+}
+.works h2 { font-size: 1.2rem; letter-spacing: .02em; text-transform: uppercase; color: var(--muted); }
+
+.works-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.work-card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.1rem 1.2rem;
+    box-shadow: var(--shadow);
+    transition: transform .14s ease, box-shadow .14s ease;
+    display: flex; flex-direction: column; gap: .6rem;
+}
+.work-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 6px rgba(0,0,0,.05), 0 10px 24px rgba(0,0,0,.06);
+}
+.work-card header { display: flex; flex-wrap: wrap; align-items: baseline; gap: .4rem; }
+.work-card h2, .work-card h3 {
+    font-size: 1.05rem; margin: 0;
+}
+.work-card h2 a, .work-card h3 a { color: var(--fg); }
+.work-card h2 a:hover, .work-card h3 a:hover { color: var(--accent); }
+
+.tagline { color: var(--muted); margin: 0; font-size: .94rem; }
+
+.badge {
+    display: inline-block;
+    font-size: .72rem;
+    padding: .12em .55em;
+    border-radius: 4px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    line-height: 1.4;
+    white-space: nowrap;
+}
+.badge.cat { background: var(--code-bg); color: var(--muted); }
+.badge.lang { background: var(--code-bg); color: var(--fg); }
+.badge.minver { background: transparent; border: 1px solid var(--border); color: var(--muted); }
+
+.work-links {
+    display: flex; flex-wrap: wrap; gap: .9rem;
+    margin-top: auto;
+    font-size: .88rem;
+}
+.work-links .more { margin-left: auto; color: var(--muted); }
+
+.page-head { margin-bottom: 2rem; }
+.page-head h1 { font-size: clamp(1.6rem, 2.4vw + 1rem, 2.4rem); margin: .2rem 0 .6rem; }
+.page-head .badges { display: flex; flex-wrap: wrap; gap: .4rem; margin: .6rem 0 1rem; }
+.page-head .back a { color: var(--muted); font-size: .9rem; }
+
+.work-body {
+    line-height: 1.75;
+}
+.work-body h2 { font-size: 1.3rem; margin-top: 2rem; border-bottom: 1px solid var(--border); padding-bottom: .3rem; }
+.work-body h3 { font-size: 1.1rem; margin-top: 1.5rem; }
+.work-body pre {
+    background: var(--code-bg);
+    padding: 1rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-size: .88rem;
+    line-height: 1.5;
+}
+.work-body code {
+    background: var(--code-bg);
+    padding: .12em .35em;
+    border-radius: 4px;
+    font-size: .9em;
+}
+.work-body pre code { background: transparent; padding: 0; }
+.work-body blockquote {
+    border-left: 3px solid var(--accent);
+    padding-left: 1rem;
+    color: var(--muted);
+    margin: 1rem 0;
+}
+
+.site-footer {
+    border-top: 1px solid var(--border);
+    padding: 1.5rem 0;
+    font-size: .88rem;
+    color: var(--muted);
+    margin-top: 4rem;
+}
+.site-footer a { color: var(--muted); }
+.site-footer a:hover { color: var(--fg); }
+
+@media (max-width: 500px) {
+    .site-header .container { flex-wrap: wrap; gap: .5rem; }
+    .site-nav { font-size: .88rem; }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,109 @@
+{%- set pg_title = config.title -%}
+{%- set pg_desc = config.description -%}
+{%- set pg_url = config.base_url ~ "/" -%}
+{%- if page -%}
+  {%- set pg_title = page.title ~ " — " ~ config.title -%}
+  {%- set pg_desc = page.description | default(value=config.description) -%}
+  {%- set pg_url = page.permalink -%}
+{%- elif section and section.title and section.title != config.title -%}
+  {%- set pg_title = section.title ~ " — " ~ config.title -%}
+  {%- set pg_desc = section.description | default(value=config.description) -%}
+  {%- set pg_url = section.permalink -%}
+{%- elif section -%}
+  {%- set pg_url = section.permalink -%}
+{%- endif -%}
+<!DOCTYPE html>
+<html lang="{{ lang }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ pg_title }}</title>
+
+    <meta name="description" content="{{ pg_desc }}">
+    <meta name="author" content="{{ config.extra.author }}">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{ pg_url | safe }}">
+
+    <link rel="alternate" hreflang="ja" href="{{ config.base_url }}/">
+    <link rel="alternate" hreflang="en" href="{{ config.base_url }}/en/">
+    <link rel="alternate" hreflang="x-default" href="{{ config.base_url }}/">
+
+    <meta property="og:type" content="{% if page %}article{% else %}website{% endif %}">
+    <meta property="og:title" content="{{ pg_title }}">
+    <meta property="og:description" content="{{ pg_desc }}">
+    <meta property="og:url" content="{{ pg_url | safe }}">
+    <meta property="og:image" content="{{ config.base_url }}{{ config.extra.og_image }}">
+    <meta property="og:locale" content="{% if lang == 'ja' %}ja_JP{% else %}en_US{% endif %}">
+    <meta property="og:locale:alternate" content="{% if lang == 'ja' %}en_US{% else %}ja_JP{% endif %}">
+    <meta property="og:site_name" content="Sota Shimozono Portfolio">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ pg_title }}">
+    <meta name="twitter:description" content="{{ pg_desc }}">
+    <meta name="twitter:image" content="{{ config.base_url }}{{ config.extra.og_image }}">
+    <meta name="twitter:creator" content="{{ config.extra.twitter_creator }}">
+
+    <meta name="theme-color" content="#0b0b0c">
+    <link rel="manifest" href="/manifest.json">
+    <link rel="icon" type="image/png" sizes="192x192" href="https://github.com/sotashimozono.png">
+    <link rel="apple-touch-icon" href="https://github.com/sotashimozono.png">
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Person",
+          "@id": "{{ config.base_url | safe }}#person",
+          "name": "{{ config.extra.author | safe }}",
+          "alternateName": "{{ config.extra.author_ja | safe }}",
+          "url": "{{ config.base_url | safe }}",
+          "image": "https://avatars.githubusercontent.com/u/187091095",
+          "sameAs": [
+            "https://github.com/{{ config.extra.github_user | safe }}",
+            "{{ config.extra.official_site | safe }}"
+          ],
+          "jobTitle": "Graduate Student in Physics",
+          "worksFor": { "@type": "Organization", "name": "{{ config.extra.affiliation | safe }}", "alternateName": "{{ config.extra.affiliation_ja | safe }}" },
+          "knowsAbout": ["Physics","Matrix Product States","Quantum Many-Body Systems","Julia Programming","Software Development"]
+        },
+        {
+          "@type": "WebSite",
+          "@id": "{{ config.base_url | safe }}#website",
+          "url": "{{ config.base_url | safe }}",
+          "name": "{{ config.title | safe }}",
+          "description": "{{ config.description | safe }}",
+          "publisher": { "@id": "{{ config.base_url | safe }}#person" }
+        }{% block jsonld_extra %}{% endblock %}
+      ]
+    }
+    </script>
+
+    <link rel="stylesheet" href="{{ get_url(path='main.css') }}">
+    {% block head_extra %}{% endblock %}
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header">
+        <div class="container">
+            <a class="brand" href="{{ config.base_url }}/">{{ config.extra.author }}</a>
+            <nav class="site-nav" aria-label="Primary">
+                <a href="{{ config.base_url }}/">Home</a>
+                <a href="{{ config.base_url }}/works/">Works</a>
+                <a href="{{ config.extra.official_site }}" rel="noopener">Official Site</a>
+                <a class="lang-toggle" href="{% if lang == 'ja' %}{{ config.base_url }}/en/{% else %}{{ config.base_url }}/{% endif %}">{% if lang == 'ja' %}EN{% else %}JA{% endif %}</a>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main" class="container">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+        <div class="container">
+            <p>© {{ now() | date(format='%Y') }} {{ config.extra.author }} · <a href="https://github.com/{{ config.extra.github_user }}" rel="noopener">GitHub</a> · <a href="{{ config.extra.official_site }}" rel="noopener">Official Site</a></p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero">
+    <h1>Sota Shimozono — <span class="accent">Julia OSS for lattice physics</span></h1>
+    <div class="lead">
+        {{ section.content | safe }}
+    </div>
+</section>
+
+{% set works = get_section(path="works/_index.md", lang=lang) %}
+
+<section class="works" aria-labelledby="works-heading">
+    <h2 id="works-heading">Featured Works</h2>
+    <div class="works-grid">
+        {% for w in works.pages %}
+        <article class="work-card" data-role="{{ w.extra.role | default(value='') }}">
+            <header>
+                <h3><a href="{{ w.permalink }}">{{ w.title }}</a></h3>
+                {% if w.extra.role %}<span class="badge role">{{ w.extra.role }}</span>{% endif %}
+                {% for cat in w.taxonomies.category | default(value=[]) %}<span class="badge cat">{{ cat }}</span>{% endfor %}
+            </header>
+            <p class="tagline">{% if lang == "ja" and w.extra.tagline_ja %}{{ w.extra.tagline_ja }}{% else %}{{ w.extra.tagline_en | default(value=w.description) }}{% endif %}</p>
+            <footer class="work-links">
+                {% if w.extra.repo %}<a href="{{ w.extra.repo }}" rel="noopener">repo</a>{% endif %}
+                {% if w.extra.docs_stable %}<a href="{{ w.extra.docs_stable }}">docs (stable)</a>{% endif %}
+                {% if w.extra.docs_dev %}<a href="{{ w.extra.docs_dev }}">docs (dev)</a>{% endif %}
+                <a class="more" href="{{ w.permalink }}">more →</a>
+            </footer>
+        </article>
+        {% endfor %}
+    </div>
+</section>
+{% endblock %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block jsonld_extra %},
+        {
+          "@type": "SoftwareSourceCode",
+          "name": "{{ page.title | safe }}",
+          "description": "{{ page.description | safe }}",
+          "url": "{{ page.permalink | safe }}",
+          {% if page.extra.repo %}"codeRepository": "{{ page.extra.repo | safe }}",{% endif %}
+          {% if page.taxonomies.language %}"programmingLanguage": "{{ page.taxonomies.language | first | safe }}",{% endif %}
+          "author": { "@id": "{{ config.base_url | safe }}#person" },
+          "license": "https://opensource.org/licenses/MIT"
+        }{% endblock %}
+
+{% block content %}
+<article class="work-page">
+    <header class="page-head">
+        <p class="back"><a href="{{ config.base_url }}/works/">← Works</a></p>
+        <h1>{{ page.title }}</h1>
+        <p class="lead">{% if lang == "ja" and page.extra.tagline_ja %}{{ page.extra.tagline_ja }}{% else %}{{ page.extra.tagline_en | default(value=page.description) }}{% endif %}</p>
+        <div class="badges">
+            {% if page.extra.role %}<span class="badge role">{{ page.extra.role }}</span>{% endif %}
+            {% for cat in page.taxonomies.category | default(value=[]) %}<span class="badge cat">{{ cat }}</span>{% endfor %}
+            {% for l in page.taxonomies.language | default(value=[]) %}<span class="badge lang">{{ l }}</span>{% endfor %}
+            {% if page.extra.julia_min %}<span class="badge minver">Julia ≥ {{ page.extra.julia_min }}</span>{% endif %}
+        </div>
+        <nav class="work-links" aria-label="External resources">
+            {% if page.extra.repo %}<a href="{{ page.extra.repo }}" rel="noopener">GitHub repository</a>{% endif %}
+            {% if page.extra.docs_stable %}<a href="{{ page.extra.docs_stable }}">docs (stable)</a>{% endif %}
+            {% if page.extra.docs_dev %}<a href="{{ page.extra.docs_dev }}">docs (dev)</a>{% endif %}
+        </nav>
+    </header>
+
+    <section class="work-body">
+        {{ page.content | safe }}
+    </section>
+</article>
+{% endblock %}

--- a/templates/section.html
+++ b/templates/section.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-head">
+    <h1>{{ section.title }}</h1>
+    {% if section.description %}<p class="lead">{{ section.description }}</p>{% endif %}
+</header>
+
+<div class="works-grid">
+    {% for w in section.pages %}
+    <article class="work-card" data-role="{{ w.extra.role | default(value='') }}">
+        <header>
+            <h2><a href="{{ w.permalink }}">{{ w.title }}</a></h2>
+            {% if w.extra.role %}<span class="badge role">{{ w.extra.role }}</span>{% endif %}
+            {% for cat in w.taxonomies.category | default(value=[]) %}<span class="badge cat">{{ cat }}</span>{% endfor %}
+        </header>
+        <p class="tagline">{% if lang == "ja" and w.extra.tagline_ja %}{{ w.extra.tagline_ja }}{% else %}{{ w.extra.tagline_en | default(value=w.description) }}{% endif %}</p>
+        <footer class="work-links">
+            {% if w.extra.repo %}<a href="{{ w.extra.repo }}" rel="noopener">repo</a>{% endif %}
+            {% if w.extra.docs_stable %}<a href="{{ w.extra.docs_stable }}">docs (stable)</a>{% endif %}
+            {% if w.extra.docs_dev %}<a href="{{ w.extra.docs_dev }}">docs (dev)</a>{% endif %}
+        </footer>
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-head">
+    <h1>{{ taxonomy.name | capitalize }}</h1>
+</header>
+
+<ul class="taxonomy-list">
+    {% for term in terms %}
+    <li><a href="{{ term.permalink }}">{{ term.name }}</a> <span class="muted">({{ term.pages | length }})</span></li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<header class="page-head">
+    <p class="back"><a href="{{ config.base_url }}/works/">← Works</a></p>
+    <h1>{{ taxonomy.name | capitalize }}: {{ term.name }}</h1>
+</header>
+
+<div class="works-grid">
+    {% for w in term.pages %}
+    <article class="work-card">
+        <header>
+            <h2><a href="{{ w.permalink }}">{{ w.title }}</a></h2>
+            {% if w.extra.role %}<span class="badge role">{{ w.extra.role }}</span>{% endif %}
+        </header>
+        <p class="tagline">{% if lang == "ja" and w.extra.tagline_ja %}{{ w.extra.tagline_ja }}{% else %}{{ w.extra.tagline_en | default(value=w.description) }}{% endif %}</p>
+        <footer class="work-links">
+            {% if w.extra.repo %}<a href="{{ w.extra.repo }}" rel="noopener">repo</a>{% endif %}
+            {% if w.extra.docs_stable %}<a href="{{ w.extra.docs_stable }}">docs (stable)</a>{% endif %}
+        </footer>
+    </article>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

Stage 2 PR-2a from the portfolio redesign plan — adds a Zola SSG scaffold alongside the existing hand-written `index.html`. This PR **only adds**: the legacy `index.html` is untouched and GitHub Pages still serves the current site from `main`. PR-2b will switch the Pages publishing source to `gh-pages`, remove the legacy artifacts, and add the deploy workflow.

## What this adds

**Config / build:**
- `config.toml` — `base_url`, `ja`/`en` multilang, `category` + `language` taxonomies, SASS compile, atom feeds
- `.gitignore` — `/public` and `.zola-cache`
- `sass/main.scss` — light/dark theme via `prefers-color-scheme`, card layout, typography, skip link

**Content (8 MD files):**
- Bilingual landing: `content/_index.md` + `_index.en.md`
- Works section index: `content/works/_index.md` + `_index.en.md`
- 5 curated work pages: `lattice-core.md`, `lattice-2d.md`, `quasi-crystal.md`, `qatlas.md`, `reversi.md` (bilingual taglines, role/repo/docs links, READMEs-derived body)

**Templates (6 Tera files):**
- `base.html` — shared `<head>` (SEO, hreflang, OG/Twitter, Person + WebSite JSON-LD `@graph`), nav, footer
- `index.html` — landing hero + featured works grid
- `section.html` — `/works/` list view
- `page.html` — individual work page, injects `SoftwareSourceCode` JSON-LD via `jsonld_extra` block
- `taxonomy_list.html` / `taxonomy_single.html` — minimal stubs

## Local build verification

```
$ zola build
-> Creating 5 pages (0 orphan) and 3 sections
Done in 46ms.
```

Verified: clean `<title>` formatting, no `&#x2F;` HTML-escape leaks in JSON-LD blocks, sass compiles to `main.css`, hreflang and OG tags well-formed.

## Stage 2 staging

| PR | Status | Scope |
|---|---|---|
| **PR-2a (this)** | ← here | Scaffold only. No site change. |
| PR-2b | next | Move root static files into `static/`, delete legacy `index.html` / `sitemap.xml`, add `deploy.yml`, switch GitHub Pages source to `gh-pages` |
| PR-2c | follow-up | OG image (1200×630), local favicons/icons, design polish |

## Test plan

- [ ] CI: HTML Validation passes on the new Zola-rendered output (CI may not yet run Zola; deploy.yml in PR-2b will)
- [ ] CI: CodeQL passes
- [ ] Visually inspect locally with `zola serve`
- [ ] Verify `_index.en.md` renders at `/en/` after PR-2b deploys
- [ ] Verify `SoftwareSourceCode` JSON-LD per work page validates with Google Rich Results Test (deferred to PR-2b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)