### PR TITLE
feat: reframe portfolio — Code Portfolio, light mode, +doiget +obsidian-remote-ssh

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 base_url = "https://codes.sota-shimozono.com"
-title = "Sota Shimozono - Physics & Code Portfolio"
-description = "Open-source Julia libraries for lattice physics — LatticeCore.jl, Lattice2D.jl, QuasiCrystal.jl, QAtlas.jl, Reversi.jl."
+title = "Sota Shimozono - Code Portfolio"
+description = "Open-source projects in Rust, TypeScript, and Julia. Package documentation is linked from each card."
 default_language = "ja"
 compile_sass = true
 generate_feeds = true
@@ -18,8 +18,8 @@ taxonomies = [
     { name = "category", feed = true },
     { name = "language" },
 ]
-title = "Sota Shimozono - Physics & Code Portfolio"
-description = "Open-source Julia libraries for lattice physics."
+title = "Sota Shimozono - Code Portfolio"
+description = "Open-source projects in Rust, TypeScript, and Julia."
 generate_feeds = true
 feed_filenames = ["atom.xml"]
 
@@ -34,6 +34,4 @@ author_ja = "下薗創太"
 github_user = "sotashimozono"
 official_site = "https://sota-shimozono.com"
 og_image = "/og/codes-1200x630.svg"
-affiliation = "The University of Tokyo"
-affiliation_ja = "東京大学"
 twitter_creator = "@sotashimozono"

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,14 +1,11 @@
 +++
-title = "Sota Shimozono - Physics & Code Portfolio"
-description = "Open-source Julia libraries for lattice physics."
+title = "Sota Shimozono - Code Portfolio"
+description = "Open-source projects in Rust, TypeScript, and Julia."
 sort_by = "weight"
 template = "index.html"
 +++
 
-A graduate student in theoretical physics at the University of Tokyo,
-working on quantum many-body systems and lattice models. I publish a
-small family of Julia libraries that backs my research.
+A list of open-source packages I maintain. Documentation for each
+sits behind the **docs** link on its card.
 
-Package documentation lives behind the **docs** links on each card.
-For research notes and a blog, see
-[Official Site (Blog, Tea)](https://sota-shimozono.com).
+For a blog and about-me, see [Official Site](https://sota-shimozono.com).

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,12 +1,11 @@
 +++
-title = "Sota Shimozono - Physics & Code Portfolio"
-description = "Open-source Julia libraries for lattice physics — LatticeCore.jl, Lattice2D.jl, QuasiCrystal.jl, QAtlas.jl, Reversi.jl."
+title = "Sota Shimozono - Code Portfolio"
+description = "Open-source projects in Rust, TypeScript, and Julia."
 sort_by = "weight"
 template = "index.html"
 +++
 
-理論物理を専攻する大学院生 (東京大学) として、量子多体系と格子模型を扱う
-ための Julia パッケージ群をオープンソースで公開しています。
+書いている OSS パッケージの一覧です。各パッケージのドキュメントは
+下のカードの **docs** リンクから。
 
-各パッケージのドキュメントは下のカードの **docs** リンクから。研究記録と
-ブログは [Official Site (Blog, Tea)](https://sota-shimozono.com) に。
+ブログ・自己紹介は [Official Site](https://sota-shimozono.com) に。

--- a/content/works/doiget.md
+++ b/content/works/doiget.md
@@ -1,0 +1,24 @@
++++
+title = "doiget"
+description = "Single-binary CLI + stdio MCP server that turns DOIs and arXiv IDs into local PDFs via official OA-first APIs."
+date = 2026-05-11
+weight = 8
+
+[taxonomies]
+category = ["Tools"]
+language = ["Rust"]
+
+[extra]
+role = "CLI / MCP server"
+repo = "https://github.com/sotashimozono/doiget"
+julia_min = ""
+tagline_en = "DOI / arXiv ID → local PDF via OA-first official APIs"
+tagline_ja = "DOI / arXiv ID から OA優先の公式 API 経由でローカル PDF を取得"
+depends_on = []
++++
+
+A general-purpose CLI for fetching scholarly PDFs from public sources. Ships a stdio MCP
+server so AI agents can drive it. Retrieves only through open-access sources (Crossref,
+Unpaywall, arXiv) by default; user-provided personal subscription credentials can be
+opted in via compile-time flags. Does not work around any access control or redistribute
+content.

--- a/content/works/obsidian-remote-ssh.md
+++ b/content/works/obsidian-remote-ssh.md
@@ -1,0 +1,22 @@
++++
+title = "obsidian-remote-ssh"
+description = "Edit remote Obsidian vaults over SSH/SFTP — like VS Code Remote-SSH for notes."
+date = 2026-05-11
+weight = 5
+
+[taxonomies]
+category = ["Tools"]
+language = ["TypeScript"]
+
+[extra]
+role = "Plugin"
+repo = "https://github.com/sotashimozono/obsidian-remote-ssh"
+julia_min = ""
+tagline_en = "Edit remote Obsidian vaults over SSH/SFTP"
+tagline_ja = "SSH/SFTP 越しに Obsidian のリモート vault を直接編集"
+depends_on = []
++++
+
+An Obsidian plugin for editing notes that live on a remote machine — similar in spirit to VS
+Code's Remote-SSH extension, but for vaults. Connects over SSH/SFTP and operates on the
+remote files directly, no local mirror required.

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -12,20 +12,6 @@
     --shadow: 0 1px 2px rgba(0,0,0,.04), 0 4px 12px rgba(0,0,0,.04);
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --bg: #0b0b0c;
-        --fg: #f5f5f5;
-        --muted: #a1a1aa;
-        --accent: #c4b5fd;
-        --accent-soft: #2a1d52;
-        --card: #131316;
-        --border: #27272a;
-        --code-bg: #1c1c1f;
-        --shadow: 0 1px 2px rgba(0,0,0,.4), 0 6px 24px rgba(0,0,0,.3);
-    }
-}
-
 * { box-sizing: border-box; }
 
 html { scroll-behavior: smooth; }

--- a/static/ai.txt
+++ b/static/ai.txt
@@ -3,16 +3,15 @@
 
 ## Site Overview
 - **Version**: 1.1.0
-- **Name**: Sota Shimozono - Physics & Code Portfolio
+- **Name**: Sota Shimozono - Code Portfolio
 - **URL**: https://codes.sota-shimozono.com
 - **Language**: Japanese (ja) / English (en)
 - **Type**: Personal portfolio and project showcase
-- **Last Updated**: 2026-05-10
+- **Last Updated**: 2026-05-11
 
 ## Author
 - **Name**: Sota Shimozono (下薗創太)
-- **Role**: Physicist and Software Engineer
-- **Affiliation**: University of Tokyo (東京大学)
+- **Role**: Software developer
 - **GitHub**: https://github.com/sotashimozono
 - **Website**: https://sota-shimozono.com
 - **Profile Image**: https://avatars.githubusercontent.com/u/187091095
@@ -33,11 +32,9 @@
 ```
 
 ## Content Topics
-- Physics research (物理学研究)
 - Programming projects (プログラミングプロジェクト)
 - Software development (ソフトウェア開発)
 - Open source contributions (オープンソース活動)
-- Academic work (学術活動)
 - Code portfolio (コードポートフォリオ)
 
 ## AI Usage Policy
@@ -65,11 +62,11 @@
 ## Notes for AI Agents
 When referencing this site:
 1. Always cite the source URL
-2. Respect the author's name and affiliation
+2. Respect the author's name
 3. Check for updates regularly (updated weekly)
-4. This is a personal portfolio site showcasing academic and professional work
+4. This is a personal portfolio site listing the author's open-source projects
 
 ---
 
-Last updated: 2026-05-10
+Last updated: 2026-05-11
 Format: LLM.txt v1.0 (https://llmstxt.org/)

--- a/static/llm.txt
+++ b/static/llm.txt
@@ -3,16 +3,15 @@
 
 ## Site Overview
 - **Version**: 1.1.0
-- **Name**: Sota Shimozono - Physics & Code Portfolio
+- **Name**: Sota Shimozono - Code Portfolio
 - **URL**: https://codes.sota-shimozono.com
 - **Language**: Japanese (ja) / English (en)
 - **Type**: Personal portfolio and project showcase
-- **Last Updated**: 2026-05-10
+- **Last Updated**: 2026-05-11
 
 ## Author
 - **Name**: Sota Shimozono (下薗創太)
-- **Role**: Physicist and Software Engineer
-- **Affiliation**: University of Tokyo (東京大学)
+- **Role**: Software developer
 - **GitHub**: https://github.com/sotashimozono
 - **Website**: https://sota-shimozono.com
 - **Profile Image**: https://avatars.githubusercontent.com/u/187091095
@@ -33,11 +32,9 @@
 ```
 
 ## Content Topics
-- Physics research (物理学研究)
 - Programming projects (プログラミングプロジェクト)
 - Software development (ソフトウェア開発)
 - Open source contributions (オープンソース活動)
-- Academic work (学術活動)
 - Code portfolio (コードポートフォリオ)
 
 ## AI Usage Policy
@@ -65,11 +62,11 @@
 ## Notes for AI Agents
 When referencing this site:
 1. Always cite the source URL
-2. Respect the author's name and affiliation
+2. Respect the author's name
 3. Check for updates regularly (updated weekly)
-4. This is a personal portfolio site showcasing academic and professional work
+4. This is a personal portfolio site listing the author's open-source projects
 
 ---
 
-Last updated: 2026-05-10
+Last updated: 2026-05-11
 Format: LLM.txt v1.0 (https://llmstxt.org/)

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -5,8 +5,8 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "background_color": "#0b0b0c",
-  "theme_color": "#0b0b0c",
+  "background_color": "#fafafa",
+  "theme_color": "#fafafa",
   "orientation": "portrait-primary",
   "icons": [
     {

--- a/static/og/codes-1200x630.svg
+++ b/static/og/codes-1200x630.svg
@@ -53,8 +53,8 @@
 
   <!-- text block -->
   <text x="80" y="260" fill="#fafafa" font-size="72" font-weight="700" letter-spacing="-1">Sota Shimozono</text>
-  <text x="80" y="340" fill="#c4b5fd" font-size="40" font-weight="500">Julia OSS for lattice physics</text>
-  <text x="80" y="400" fill="#a1a1aa" font-size="26">LatticeCore · Lattice2D · QuasiCrystal · QAtlas · Reversi</text>
+  <text x="80" y="340" fill="#c4b5fd" font-size="40" font-weight="500">Code Portfolio</text>
+  <text x="80" y="400" fill="#a1a1aa" font-size="26">Rust · TypeScript · Julia · OSS projects</text>
 
   <!-- footer brand -->
   <line x1="80" y1="530" x2="1120" y2="530" stroke="#27272a" stroke-width="1"/>

--- a/templates/base.html
+++ b/templates/base.html
@@ -43,7 +43,7 @@
     <meta name="twitter:image" content="{{ config.base_url }}{{ config.extra.og_image }}">
     <meta name="twitter:creator" content="{{ config.extra.twitter_creator }}">
 
-    <meta name="theme-color" content="#0b0b0c">
+    <meta name="theme-color" content="#fafafa">
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="apple-touch-icon" href="/favicon.svg">
@@ -63,9 +63,7 @@
             "https://github.com/{{ config.extra.github_user | safe }}",
             "{{ config.extra.official_site | safe }}"
           ],
-          "jobTitle": "Graduate Student in Physics",
-          "worksFor": { "@type": "Organization", "name": "{{ config.extra.affiliation | safe }}", "alternateName": "{{ config.extra.affiliation_ja | safe }}" },
-          "knowsAbout": ["Physics","Matrix Product States","Quantum Many-Body Systems","Julia Programming","Software Development"]
+          "knowsAbout": ["Rust","TypeScript","Julia","Software Development","Open Source"]
         },
         {
           "@type": "WebSite",

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <section class="hero">
-    <h1>Sota Shimozono — <span class="accent">Julia OSS for lattice physics</span></h1>
+    <h1>Sota Shimozono — <span class="accent">Code Portfolio</span></h1>
     <div class="lead">
         {{ section.content | safe }}
     </div>


### PR DESCRIPTION
## Summary

Reframe per feedback: drop the physics-specific framing, present as a neutral **Code Portfolio**. Fix light mode. Add two more Featured Works that aren't Julia.

## Changes

**Framing (the "lattice physics" framing was wrong):**
- Hero text: `Julia OSS for lattice physics` → `Code Portfolio`
- `<title>`, OG title, Twitter title, description: drop `Physics &` and the `Julia libraries for lattice physics` phrasing
- Person JSON-LD: drop `worksFor` (University of Tokyo) and `jobTitle: Graduate Student in Physics`; `knowsAbout` → languages instead of physics topics
- `ai.txt` / `llm.txt`: drop `Affiliation: University of Tokyo`, drop `Physics research` content topic; role → `Software developer`
- `content/_index.md` and `_index.en.md`: rewrite landing copy to match
- OG image SVG: text block updated to `Code Portfolio` + `Rust · TypeScript · Julia · OSS projects`

**Light mode fixed:**
- `sass/main.scss`: remove the `@media (prefers-color-scheme: dark)` override block (was auto-switching the site to dark when OS theme was dark; user wants light always for this kind of page)
- `<meta name="theme-color">` and `manifest.json` `background_color` / `theme_color`: `#0b0b0c` → `#fafafa` to match

**Featured Works (now 7, was 5):**
| weight | name | language | role |
|---|---|---|---|
| 5  | obsidian-remote-ssh | TypeScript | Plugin |
| 8  | doiget | Rust | CLI / MCP server |
| 10 | LatticeCore.jl | Julia | Foundation |
| 20 | Lattice2D.jl | Julia | Geometry |
| 30 | QuasiCrystal.jl | Julia | Geometry |
| 40 | QAtlas.jl | Julia | Reference DB |
| 50 | Reversi.jl | Julia | Game / RL |

## Verified locally

\`zola build\` → 7 pages + 3 sections. \`grep\` on \`public/index.html\`: no \`Julia OSS for lattice physics\`, no \`University of Tokyo\`, no \`東京大学\`; all 7 works appear in the grid; hero says \`Code Portfolio\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)